### PR TITLE
Add specific lot disposal strategies (beta)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
       "LabeledStatement",
       "WithStatement"
     ],
+    "prefer-destructuring": ["error", {"object": true, "array": false}],
     "strict": "off"
   }
 }

--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ config.getDisposalMethod = function getDisposalMethod(year) {
   let method = config.disposalMethod[year];
 
   // convert string into object
-  if (typeof(method) === 'string' || typeof(method) === 'undefined') {
+  if (typeof method === 'string' || typeof method === 'undefined') {
     method = { method };
   }
 

--- a/app.js
+++ b/app.js
@@ -13,25 +13,20 @@ const importFile = require('./src/sources/file');
 config.getDisposalMethod = function getDisposalMethod(year) {
   let method = config.disposalMethod[year];
 
-  // default to FIFO
-  if (method === undefined) {
-    method = 'FIFO';
-  }
-
-  // convert into object
-  if (['FIFO', 'LIFO'].includes(method)) {
+  // convert string into object
+  if (typeof(method) === 'string' || typeof(method) === 'undefined') {
     method = { method };
   }
 
-  // validate
-  if (!['FIFO', 'LIFO', 'Minimize'].includes(method.method)) {
-    throw new Error(`invalid disposalMethod for ${year}: ${method.method}`);
+  // default to FIFO
+  if (!method.method) {
+    method.method = 'FIFO';
   }
 
-  if (method.method === 'Minimize') {
+  if (method.method === 'Estimate') {
     for (const prop of ['shortTermTaxRate', 'longTermTaxRate']) {
       if (!method[prop] || method[prop] <= 0 || method[prop] >= 1) {
-        throw new Error(`invalid minimize ${prop} for ${year}: ${method[prop]}`);
+        throw new Error(`invalid ${prop} for ${year}: ${method[prop]}`);
       }
     }
   }

--- a/config.js.example
+++ b/config.js.example
@@ -3,8 +3,12 @@ module.exports = {
   // valid options: FIFO, LIFO
   // default: FIFO
   disposalMethod: {
-    2016: 'FIFO',
-    2017: 'FIFO',
+    // 2016: 'FIFO',
+    // 2017: 'FIFO',
+    // 2018: 'FIFO',
+
+    // BETA: Optimize estimated taxes by selling specific lots
+    // 2018: { method: 'Minimize', shortTermTaxRate: '0.35', longTermTaxRate: '0.15' },
   },
   accounts: [
     {

--- a/config.js.example
+++ b/config.js.example
@@ -1,14 +1,17 @@
 module.exports = {
   // choose disposal method to use
-  // valid options: FIFO, LIFO
+  // valid options: FIFO, LIFO, TaxMin, Estimate
   // default: FIFO
   disposalMethod: {
     // 2016: 'FIFO',
     // 2017: 'FIFO',
     // 2018: 'FIFO',
 
-    // BETA: Optimize estimated taxes by selling specific lots
-    // 2018: { method: 'Minimize', shortTermTaxRate: '0.35', longTermTaxRate: '0.15' },
+    // BETA: TaxMin (prioritize in order: ST loss, LT loss, LT gain, ST gain)
+    // 2018: 'TaxMin',
+
+    // BETA: Sell lot with lowest estimated tax liability
+    // 2018: { method: 'Estimate', shortTermTaxRate: '0.35', longTermTaxRate: '0.15' },
   },
   accounts: [
     {

--- a/src/calculategains.js
+++ b/src/calculategains.js
@@ -101,6 +101,7 @@ function findMinimizedTaxHold(amountRemaining, tx, holds, method) {
 
   // search for lot to sell which causes lowest tax due
   let lowestTaxAmount;
+  let lowestTaxPerUnit;
   let lowestTaxHold;
 
   for (const hold of holds) {
@@ -126,6 +127,9 @@ function findMinimizedTaxHold(amountRemaining, tx, holds, method) {
       estimatedTaxDue = gain.mul(method.shortTermTaxRate);
     }
 
+    // normalize estimated tax per unit so that we don't bias selling small lots
+    const estimatedTaxPerUnit = estimatedTaxDue.div(disposalAmount);
+
     // console.log(
     //   isLongTerm(hold.timestamp) ? 'long' : 'short',
     //   hold.timestamp,
@@ -134,8 +138,9 @@ function findMinimizedTaxHold(amountRemaining, tx, holds, method) {
     //   gain.toString(),
     //   estimatedTaxDue.toString());
 
-    if (lowestTaxAmount === undefined || lowestTaxAmount.gt(estimatedTaxDue)) {
+    if (lowestTaxPerUnit === undefined || lowestTaxPerUnit.gt(estimatedTaxPerUnit)) {
       lowestTaxAmount = estimatedTaxDue;
+      lowestTaxPerUnit = estimatedTaxPerUnit;
       lowestTaxHold = hold;
     }
   }

--- a/src/calculategains.js
+++ b/src/calculategains.js
@@ -171,7 +171,6 @@ function findMinimizedTaxHold(amountRemaining, tx, holds, method) {
   }
 
   // search for lot to sell which causes lowest tax due
-  let lowestTaxAmount;
   let lowestTaxPerUnit;
   let lowestTaxHold;
 
@@ -191,7 +190,6 @@ function findMinimizedTaxHold(amountRemaining, tx, holds, method) {
 
     // calculate estimated tax for this hold
     let estimatedTaxDue;
-    let estimatedTaxTerm;
     if (isLongTerm(hold.timestamp)) {
       estimatedTaxDue = gain.mul(method.longTermTaxRate);
     } else {
@@ -210,7 +208,6 @@ function findMinimizedTaxHold(amountRemaining, tx, holds, method) {
     //   estimatedTaxDue.toString());
 
     if (lowestTaxPerUnit === undefined || lowestTaxPerUnit.gt(estimatedTaxPerUnit)) {
-      lowestTaxAmount = estimatedTaxDue;
       lowestTaxPerUnit = estimatedTaxPerUnit;
       lowestTaxHold = hold;
     }
@@ -218,7 +215,7 @@ function findMinimizedTaxHold(amountRemaining, tx, holds, method) {
 
   // console.log('found:',
   //   isLongTerm(lowestTaxHold.timestamp) ? 'long' : 'short',
-  //   lowestTaxAmount.toString(),
+  //   lowestTaxPerUnit.toString(),
   //   lowestTaxHold.timestamp,
   //   tx.usdPrice,
   //   lowestTaxHold.usdPrice,
@@ -306,7 +303,7 @@ async function calculateGainsForCurrency(currency, config) {
 
           // remove this hold from holds array
           const prevHoldsLength = holds.length;
-          var holdIndex = holds.indexOf(hold);
+          const holdIndex = holds.indexOf(hold);
           if (holdIndex >= 0) {
             holds.splice(holdIndex, 1);
           }


### PR DESCRIPTION
Two new disposal strategies:

* `TaxMin`: prioritize disposals in order (ST loss, LT loss, LT gain, ST gain)
* `Estimate`: Estimates tax due on all available lots, and sells lot with lowest estimated tax per coin